### PR TITLE
Feature/update existing export

### DIFF
--- a/readux/accounts/urls.py
+++ b/readux/accounts/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
-from .views import AccountErrorView
+from .views import AccountErrorView, GithubRepositoryList
 
 urlpatterns = [
     url(r'^error/', AccountErrorView.as_view(), name='error'),
+    url(r'^github-repos/', GithubRepositoryList.as_view(), name='github-repos'),
 ]

--- a/readux/accounts/views.py
+++ b/readux/accounts/views.py
@@ -1,7 +1,14 @@
 from django.contrib import messages
+from django.core.cache import cache
 from django.core.urlresolvers import reverse
-from django.views.generic import TemplateView
+from django.http import JsonResponse, HttpResponseBadRequest
+from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_cookie
+from django.views.generic import TemplateView, View
+from django.utils.decorators import method_decorator
 from eulcommon.djangoextras.http import HttpResponseSeeOtherRedirect
+
+from readux.books.github import GithubApi, GithubAccountNotFound
 
 
 class AccountErrorView(TemplateView):
@@ -22,3 +29,34 @@ class AccountErrorView(TemplateView):
         if not messages.get_messages(request):
             return HttpResponseSeeOtherRedirect(reverse('site-index'))
         return super(AccountErrorView, self).get(request, *args, **kwargs)
+
+
+class GithubRepositoryList(View):
+    '''List of the current user's GitHub repositories, in a json format
+    for use with jquery-ui autocomplete.
+
+    GitHub repository list is cached to avoid hitting the GitHub API
+    more frequently than necessary.  Caching currently uses the default
+    configured cache timeout.
+    '''
+
+    def cache_key(self):
+        return 'github-repos-%s' % self.request.user
+
+    def get(self, request, *args, **kwargs):
+        # cache repo list to avoid hitting github too frequently
+        # using default cache timeout for now
+        repo_list = cache.get(self.cache_key())
+        if repo_list is None:
+            try:
+                github = GithubApi.connect_as_user(request.user)
+            except GithubAccountNotFound:
+                return HttpResponseBadRequest('GitHub account not found')
+
+            repos = github.list_user_repos()
+            # convert into format expected by jqueryui
+            repo_list = [{'label': repo['full_name'], 'value': repo['html_url']}
+                         for repo in repos]
+            cache.set(self.cache_key(), repo_list)
+        return JsonResponse(repo_list, safe=False)
+

--- a/readux/annotations/migrations/0003_annotation_group_and_permissions.py
+++ b/readux/annotations/migrations/0003_annotation_group_and_permissions.py
@@ -24,10 +24,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterModelOptions(
             name='annotation',
-            options={'permissions': (('view_annotation', 'View annotation'),)},
-        ),
-        migrations.AlterModelOptions(
-            name='annotation',
             options={'permissions': (('view_annotation', 'View annotation'), ('admin_annotation', 'Manage annotation'))},
         ),
     ]

--- a/readux/books/export.py
+++ b/readux/books/export.py
@@ -248,10 +248,11 @@ def update_gitrepo(user, repo_url, vol, tei, page_one=None):
     # and available before running the ruby script
     teifile.close()
 
-    # remove all annotations so that if an annotation is removed in
-    # readux it will be removed in the export (annotations that are
-    # unchanged should be restored by the tei jekyll import)
-    repo.index.remove(['_annotations/*'])
+    # remove all annotations and tag pages so that if an annotation is removed
+    # or a tag is no longer used in readux, it will be removed in the export
+    # (annotations and tags that are unchanged will be restored by the tei
+    # jekyll import, and look unchanged to git if no different)
+    repo.index.remove(['_annotations/*', 'tags/*'])
 
     # run the script to get a freash import of tei as jekyll site content
     logger.debug('Running jekyll import TEI facsimile script')

--- a/readux/books/export.py
+++ b/readux/books/export.py
@@ -158,8 +158,12 @@ def website_gitrepo(user, repo_name, vol, tei, page_one=None):
     config_file_path = os.path.join(jekyll_dir, '_config.yml')
     with open(config_file_path, 'r') as configfile:
         config_data = yaml.load(configfile)
-    config_data['url'] = github_pages_url
-    config_data['baseurl'] = '/%s' % repo_name
+
+    # split out github pages url into the site url and path
+    parsed_gh_url = urlparse(github_pages_url)
+    config_data['url'] = '%s://%s' % (parsed_gh_url.scheme,
+                                      parsed_gh_url.netloc)
+    config_data['baseurl'] = parsed_gh_url.path.rstrip('/')
     with open(config_file_path, 'w') as configfile:
         yaml.safe_dump(config_data, configfile,
             default_flow_style=False)

--- a/readux/books/export.py
+++ b/readux/books/export.py
@@ -248,6 +248,11 @@ def update_gitrepo(user, repo_url, vol, tei, page_one=None):
     # and available before running the ruby script
     teifile.close()
 
+    # remove all annotations so that if an annotation is removed in
+    # readux it will be removed in the export (annotations that are
+    # unchanged should be restored by the tei jekyll import)
+    repo.index.remove(['_annotations/*'])
+
     # run the script to get a freash import of tei as jekyll site content
     logger.debug('Running jekyll import TEI facsimile script')
     import_command = ['jekyllimport_teifacsimile', '-q', teifile.name]

--- a/readux/books/forms.py
+++ b/readux/books/forms.py
@@ -57,10 +57,10 @@ class VolumeExport(forms.Form):
     )
     #: help text for export mode choices
     mode_help = [
-        'Download a new Jekyll site as a zip file',
+        'Download a zip file with all Jekyll site contents',
         '''Create a new GitHub repository with the generated Jekyll
-                site content and publish it using Github Pages''',
-        'Update existing GitHub repo'
+            site content and publish it using Github Pages''',
+        'Update a Jekyll site in an existing GitHub repo'
     ]
 
     #: github repository name to be created
@@ -71,7 +71,8 @@ class VolumeExport(forms.Form):
     #: github repository to be updated, if update is selected
     update_repo = forms.CharField(
         label='GitHub repository to update',
-        help_text='Existing repository to be updated')
+        help_text='Existing repository to be updated ' +
+                  '(type to search and select from your GitHub repos)')
 
     # flag to allow suppressing annotation choice display when
     # user does not belong to any annotation groups

--- a/readux/books/forms.py
+++ b/readux/books/forms.py
@@ -48,7 +48,7 @@ class VolumeExport(forms.Form):
     mode = forms.ChoiceField(
         label='Export mode',
         choices=[
-            ('jekyll', 'Download'),
+            ('download', 'Download'),
             ('github', 'Publish on GitHub'),
             ('github_update', 'Update existing Github repo')
         ],
@@ -65,12 +65,12 @@ class VolumeExport(forms.Form):
 
     #: github repository name to be created
     github_repo = forms.SlugField(
-        label='GitHub repository name',
+        label='GitHub repository name', required=False,
         help_text='Name of the repository to be created, which will also ' +
         'determine the GitHub pages URL.')
     #: github repository to be updated, if update is selected
     update_repo = forms.CharField(
-        label='GitHub repository to update',
+        label='GitHub repository to update', required=False,
         help_text='Existing repository to be updated ' +
                   '(type to search and select from your GitHub repos)')
 

--- a/readux/books/forms.py
+++ b/readux/books/forms.py
@@ -43,23 +43,41 @@ class VolumeExport(forms.Form):
         label='Annotations to export',
         help_text='Individual annotations or all annotations shared with ' +
         'a single group')
-    #: boolean, should the export be sent to github?
-    github = forms.BooleanField(
-        label='Publish on GitHub',
-        help_text='Create a new GitHub repository with the ' +
-        'generated Jekyll site content and publish it using Github Pages.',
-        required=False)
+
+    #: export mode
+    mode = forms.ChoiceField(
+        label='Export mode',
+        choices=[
+            ('jekyll', 'Download'),
+            ('github', 'Publish on GitHub'),
+            ('github_update', 'Update existing Github repo')
+        ],
+        widget=forms.RadioSelect,
+        help_text='Choose how to export your volume as a Jekyll site.'
+    )
+    #: help text for export mode choices
+    mode_help = [
+        'Download a new Jekyll site as a zip file',
+        '''Create a new GitHub repository with the generated Jekyll
+                site content and publish it using Github Pages''',
+        'Update existing GitHub repo'
+    ]
+
     #: github repository name to be created
     github_repo = forms.SlugField(
         label='GitHub repository name',
         help_text='Name of the repository to be created, which will also ' +
         'determine the GitHub pages URL.')
+    #: github repository to be updated, if update is selected
+    update_repo = forms.CharField(
+        label='GitHub repository to update',
+        help_text='Existing repository to be updated')
 
     # flag to allow suppressing annotation choice display when
     # user does not belong to any annotation groups
     hide_annotation_choice = False
 
-    def __init__(self, user, *args, **kwargs):
+    def __init__(self, user, user_has_github=False, *args, **kwargs):
         self.user = user
 
         # initialize normally
@@ -72,6 +90,10 @@ class VolumeExport(forms.Form):
         if len(self.fields['annotations'].choices) == 1:
             self.hide_annotation_choice = True
 
+        # if not user_has_github:
+            # would be nice to mark github options as disabled
+            # TODO: mark github radio button options as disabled
+
     def annotation_authors(self):
         # choices for annotations to be exported:
         # individual user, or annotations visible by group
@@ -81,3 +103,4 @@ class VolumeExport(forms.Form):
                 choices.append((group.annotationgroup.annotation_id,
                                 'All annotations shared with %s' % group.name))
         return choices
+

--- a/readux/books/forms.py
+++ b/readux/books/forms.py
@@ -50,7 +50,7 @@ class VolumeExport(forms.Form):
         choices=[
             ('download', 'Download'),
             ('github', 'Publish on GitHub'),
-            ('github_update', 'Update existing Github repo')
+            ('github_update', 'Update an existing Github repo')
         ],
         widget=forms.RadioSelect,
         help_text='Choose how to export your volume as a Jekyll site.'
@@ -72,7 +72,9 @@ class VolumeExport(forms.Form):
     update_repo = forms.CharField(
         label='GitHub repository to update', required=False,
         help_text='Existing repository to be updated ' +
-                  '(type to search and select from your GitHub repos)')
+                  '(type to search and select from your GitHub repos). ' +
+                  'If you specified a start page in your previous export, ' +
+                  'you should specify the same one to avoid changes.')
 
     # flag to allow suppressing annotation choice display when
     # user does not belong to any annotation groups

--- a/readux/books/github.py
+++ b/readux/books/github.py
@@ -119,11 +119,8 @@ class GithubApi(object):
         if text is not None:
             data['body'] = text
 
-        print 'pr url = , %s/repos/%s/pulls' % (self.url, repo)
         response = self.session.post('%s/repos/%s/pulls' % (self.url, repo),
                                      data=json.dumps(data))
-        print response
-        print response.content
         if response.status_code == requests.codes.created:
             return response.json()
         else:

--- a/readux/books/github.py
+++ b/readux/books/github.py
@@ -84,5 +84,20 @@ class GithubApi(object):
         # but that includes org repos user has access to
         # could specify type, but default of owner is probably fine for now
         response = self.session.get('%s/users/%s/repos' % (self.url, user))
+
         if response.status_code == requests.codes.ok:
             return response.json()
+
+    def list_user_repos(self):
+        '''Get a list of the current user's repositories'''
+        response = self.session.get('%s/user/repos' % self.url)
+        if response.status_code == requests.codes.ok:
+            repos = response.json()
+            # repository list is paged; if there is a rel=next link,
+            # there is more content
+            while response.links.get('next', None):
+                # for now, assuming that if the first response is ok
+                # subsequent ones will be too
+                response = self.session.get(response.links['next']['url'])
+                repos.extend(response.json())
+            return repos

--- a/readux/books/management/commands/find_test_pids.py
+++ b/readux/books/management/commands/find_test_pids.py
@@ -47,9 +47,7 @@ class Command(BaseCommand):
             default=False,
             help='Calculate total size of volumes and associated objects')
 
-
     def handle(self, *args, **options):
-        print options
         # expects a plain text file with a list of pids,
         # one per line
         start = time.time()

--- a/readux/books/templates/books/volume_export.html
+++ b/readux/books/templates/books/volume_export.html
@@ -54,7 +54,7 @@
 
     {% else %}
 
-    {{ export_for.non_field_errors }}
+    {{ export_form.non_field_errors }}
     <form class="volume-webexport form-horizontal" method="POST">{% csrf_token %}
     {% for field in export_form %}
     {# TODO: github options should be disabled if user does not have a github account #}

--- a/readux/books/templates/books/volume_export.html
+++ b/readux/books/templates/books/volume_export.html
@@ -44,6 +44,14 @@
       <a href="https://help.github.com/categories/github-pages-basics/">Github
       Pages help documentation</a>.</p>
 
+    {% elif github_update %}
+      <div class="alert alert-success">GitHub jekyll site update succeeded.</div>
+
+      <p>A new <a href="{{ pullrequest_url }}">pull request</a> has been created
+      on your <a href="{{ repo_ur }}">GitHub repository</a> with all the latest
+      changes.  You can review the changes and merge them into your
+      published edition.</p>
+
     {% else %}
 
     {{ export_for.non_field_errors }}

--- a/readux/books/templates/books/volume_export.html
+++ b/readux/books/templates/books/volume_export.html
@@ -1,5 +1,5 @@
 {% extends 'site_base.html' %}
-{% load static widget_tweaks %}
+{% load static widget_tweaks readux_utils %}
 
 
 {% block page-subtitle %}{{ vol.display_label }} | Export {% endblock %}
@@ -7,6 +7,9 @@
 {% block javascript %}
   {{ block.super }}
    <script type="text/javascript" src="{% static 'ext/js.cookie.js' %}"></script>
+  <script type="text/javascript" src="//emory-lits-labs.github.io/annotator-meltdown-zotero/build/0.1.0/annotator.meltdown.zotero.min.js"></script> <!-- includes jquery-ui autocomplete -->
+  <link rel="stylesheet" type="text/css" href="//emory-lits-labs.github.io/annotator-meltdown-zotero/build/0.1.0/annotator.meltdown.zotero.min.css" />
+
 {% endblock %}
 
 {% block content %}
@@ -45,20 +48,29 @@
 
     {{ export_for.non_field_errors }}
     <form class="volume-webexport form-horizontal" method="POST">{% csrf_token %}
-        {% for field in export_form %}
-          {% if field.name = 'github' %}
-          <div class="form-group{% if field.errors %} has-error{% endif %}">
-            <div class="checkbox">
-              <label>{{ field }} {{ field.label }}</label>
+    {% for field in export_form %}
+    {# TODO: github options should be disabled if user does not have a github account #}
+    {# TODO: add visual indication for disabled fields #}
+          {% if field.name = 'mode' %}
+          {# special handling for export mode radio buttons & help text #}
+          <div class="help-block">{{ field.help_text}}</div>
+          {% for radio in field %}
+            <div class="radio">
+              <label for="{{ radio.id_for_label }}">
+                  {{ radio.tag }} {{ radio.choice_label}}
+              </label>
+              {% with forloop.counter|cut:' ' as index %}
+                <div class="help-block">{{ export_form.mode_help|slice:index|last }}</div>
+              {% endwith %}
             </div>
-            <div class="help-block">{{ field.help_text}}</div>
-            <div class="text-warning">{{ field.errors }}</div>
-          </div>
+          {% endfor %}
+          <div class="text-warning">{{ field.errors }}</div>
+
           {% elif field.name = 'annotations' and export_form.hide_annotation_choice %}
           {# hide annotation choice when flag is set (i.e., only one choice available) #}
             {{ field|add_class:"hidden" }}
           {% else %}
-        <div class="form-group{% if field.errors %} has-error{% endif %}">
+        <div class="form-group{% if field.errors %} has-error{% endif %}"{% if field.name = 'github_repo' or field.name = 'update_repo' %}style="display:none"{% endif %}>
             <label for="{{ field.name }}">{{ field.label }}</label>
             {{ field|add_class:"form-control" }}
             <div class="help-block">{{ field.help_text}}</div>
@@ -76,6 +88,33 @@
         </form>
 
     {% endif %}
+
+    <script>
+    {# Show/hide subportions of the form based on export mode #}
+      $(document).ready(function(){
+        var transition = 500;
+        var github_repo = $("div.form-group:has(#id_github_repo)");
+        var update_repo = $("div.form-group:has(#id_update_repo)");
+        $("input[type=radio][name=mode]").change(function() {
+          // hide everything by default, then show as appropriate by mode
+          github_repo.hide(transition);
+          update_repo.hide(transition);
+          if (this.value == 'github') {
+            github_repo.show(transition);
+          } else if (this.value == 'github_update') {
+            update_repo.show(transition);
+          }
+        });
+
+        // load github repo data once, and use as variable data source
+        $.getJSON("{% url 'accounts:github-repos' %}", function( data ) {
+            $("#id_update_repo").autocomplete({
+                source: data
+            });
+        });
+
+      });
+    </script>
 
   {% endif %}  {# logged in user #}
 

--- a/readux/books/templates/books/volume_export.html
+++ b/readux/books/templates/books/volume_export.html
@@ -60,7 +60,7 @@
     {# TODO: github options should be disabled if user does not have a github account #}
     {# TODO: add visual indication for disabled fields #}
           {% if field.name = 'mode' %}
-          {# special handling for export mode radio buttons & help text #}
+          {# special handling for export mode radio buttons and help text #}
           <div class="help-block">{{ field.help_text}}</div>
           {% for radio in field %}
             <div class="radio">
@@ -115,6 +115,7 @@
         });
 
         // load github repo data once, and use as variable data source
+        // for the update repository autocomplete input
         $.getJSON("{% url 'accounts:github-repos' %}", function( data ) {
             $("#id_update_repo").autocomplete({
                 source: data

--- a/readux/books/templates/books/volume_export.html
+++ b/readux/books/templates/books/volume_export.html
@@ -48,7 +48,7 @@
       <div class="alert alert-success">GitHub jekyll site update succeeded.</div>
 
       <p>A new <a href="{{ pullrequest_url }}">pull request</a> has been created
-      on your <a href="{{ repo_ur }}">GitHub repository</a> with all the latest
+      on your <a href="{{ repo_url }}">GitHub repository</a> with all the latest
       changes.  You can review the changes and merge them into your
       published edition.</p>
 

--- a/readux/books/views.py
+++ b/readux/books/views.py
@@ -683,7 +683,6 @@ class AnnotatedVolumeExport(DetailView, FormMixin, ProcessFormView,
         if export_form.is_valid():
             cleaned_data = export_form.cleaned_data
             export_mode = cleaned_data['mode']
-            print 'mode == ', export_mode
 
             # if github export or update is requested, make sure user
             # has a github account available to use for access
@@ -700,8 +699,6 @@ class AnnotatedVolumeExport(DetailView, FormMixin, ProcessFormView,
                 if 'public_repo' not in gh.oauth_scopes():
                     return self.render(request, error=self.github_scope_msg)
         else:
-            print 'form is not valid!'
-            print export_form.errors
             return self.render(request)
 
         # determine which annotations should be loaded

--- a/readux/books/views.py
+++ b/readux/books/views.py
@@ -613,7 +613,6 @@ class AnnotatedVolumeExport(DetailView, FormMixin, ProcessFormView,
         'Please re-authorize your GitHub account to enable ' + \
         ' the permissions needed for export.'
 
-    # @method_decorator(last_modified(view_helpers.volume_modified))
     def dispatch(self, *args, **kwargs):
         return super(AnnotatedVolumeExport, self).dispatch(*args, **kwargs)
 

--- a/readux/settings.py
+++ b/readux/settings.py
@@ -211,7 +211,7 @@ if DEBUG or DEV_ENV:
         import debug_toolbar
         # import to ensure debug panel is available before configuring
         # (not yet in released version of eulfedora)
-        from eulfedora import debug_panel
+        # from eulfedora import debug_panel
         INSTALLED_APPS.append('debug_toolbar')
     except ImportError:
         pass

--- a/requirements/minimum.txt
+++ b/requirements/minimum.txt
@@ -38,5 +38,5 @@ mistune
 gitpython
 pyyaml
 # jekyll theme for zipfile used in export functionality
--e git+https://github.com/emory-libraries-ecds/digitaledition-jekylltheme.git@0.6#egg=digitaledition-jekylltheme
+-e git+https://github.com/emory-libraries-ecds/digitaledition-jekylltheme.git@develop#egg=digitaledition-jekylltheme
 django-guardian

--- a/requirements/minimum.txt
+++ b/requirements/minimum.txt
@@ -1,6 +1,7 @@
 Django>=1.8,<1.9
 eulxml>=0.22
-eulfedora>=1.5
+#eulfedora>=1.5
+-e git://github.com/emory-libraries/eulfedora.git@develop#egg=eulfedora
 # dev eulcm content model objects (until initial eulcm release)
 -e git://github.com/emory-libraries/eulcm.git@4c97a98c79#egg=eulcm
 # require at least downtime 1.0.4 for exempting exact urls


### PR DESCRIPTION
Adds a new option to the export form to update an existing github repo.  Uses github api to get a list of repositories (uses autocomplete on the form to select).  Update method clones the repo, creates a new branch and runs the import script, adds & commits any updated files, and then pushes it to github and creates a pull request.