### PR TITLE
small typo fix, extension of tei XSL, and loris suffix

### DIFF
--- a/readux/books/models.py
+++ b/readux/books/models.py
@@ -120,6 +120,7 @@ class IIIFImage(iiif.IIIFImageClient):
 
     api_endpoint = settings.IIIF_API_ENDPOINT
     image_id_prefix = getattr(settings, 'IIIF_ID_PREFIX', '')
+    image_id_suffix = getattr(settings, 'IIIF_ID_SUFFIX', '')
     pid = None
     long_side = 'height'
 
@@ -139,8 +140,8 @@ class IIIFImage(iiif.IIIFImageClient):
         return copy
 
     def get_image_id(self):
-        'image id, based on fedora pid and configured prefix'
-        return '%s%s' % (self.image_id_prefix, self.pid)
+        'image id, based on fedora pid, configured prefix, and optional suffix'
+        return '%s%s%s' % (self.image_id_prefix, self.pid, self.image_id_suffix)
 
     # NOTE: using long edge instead of specifying both with exact
     # results in cleaner urls/filenams (no !), and more reliable result
@@ -474,7 +475,7 @@ class PageV1_1(Page):
         save the result as tei datastream content.'''
         # check to make sure generated TEI is valid
         pagetei = self.generate_tei()
-        if not pageteidoc.schema_valid():
+        if not pagetei.schema_valid():
             raise Exception('TEI is not valid according to configured schema')
         # load as tei should maybe happen here instead of in generate
         self.tei.content = pagetei

--- a/readux/books/ocr_to_teifacsimile.xsl
+++ b/readux/books/ocr_to_teifacsimile.xsl
@@ -72,9 +72,20 @@
       <xsl:copy-of select="@xml:id"/>
       <xsl:attribute name="type">page</xsl:attribute>
       <xsl:attribute name="ulx">0</xsl:attribute>
-      <xsl:attribute name="uly">0</xsl:attribute>
-      <xsl:attribute name="lrx"><xsl:value-of select="@WIDTH"/></xsl:attribute>
-      <xsl:attribute name="lry"><xsl:value-of select="@HEIGHT"/></xsl:attribute>
+      <xsl:attribute name="uly">0</xsl:attribute>            
+      <!-- ABBYY Finereader and ABBYY Recognition Server encode page dimensions in different ways.  Catch that here.-->
+      <xsl:choose>                
+        <!-- ABBYY Finereader 8.0, with page dimensions in <alto:Page> element -->
+        <xsl:when test="@WIDTH|@HEIGHT">
+          <xsl:attribute name="lrx"><xsl:value-of select="@WIDTH"/></xsl:attribute>
+          <xsl:attribute name="lry"><xsl:value-of select="@HEIGHT"/></xsl:attribute>
+        </xsl:when>                
+        <!-- ABBYY Recognition Server with page dimensions in child <alto:PrintSpace> element -->
+        <xsl:when test="./alto:PrintSpace">
+          <xsl:attribute name="lrx"><xsl:value-of select="alto:PrintSpace/@WIDTH"/></xsl:attribute>                    
+          <xsl:attribute name="lry"><xsl:value-of select="alto:PrintSpace/@HEIGHT"/></xsl:attribute>
+        </xsl:when>
+      </xsl:choose>            
       <xsl:element name="graphic">
         <xsl:attribute name="url"><xsl:value-of select="$graphic_url"></xsl:value-of></xsl:attribute>
       </xsl:element>

--- a/readux/localsettings.py.dist
+++ b/readux/localsettings.py.dist
@@ -157,6 +157,8 @@ DOWNTIME_ALLOWED_IPS = ['127.0.0.1']
 IIIF_API_ENDPOINT = 'http://loris.server/'
 # optional prefix, for use with Loris templating http resolver; include
 IIIF_ID_PREFIX = 'prefix:'
+# optional suffix, used when loris expects datastream dilineation (e.g. '|source-image')
+IIIF_ID_SUFFIX = ''
 
 
 # override default git author name if desired


### PR DESCRIPTION
- small typo in `readux/books/models.py`
- add `IIIF_ID_SUFFIX` to allow suffixes (e.g. fedora datastreams) for Loris IDs
- extend `readux/books/ocr_to_teifacsimile.xsl` to pick up page / print dimensions for Abbyy Recognition Server
