### PR TITLE
abstracting collection owner to localsettings

### DIFF
--- a/readux/books/views.py
+++ b/readux/books/views.py
@@ -917,4 +917,4 @@ class PageImage(ProxyView):
             # to allow jekyll sites to use for deep zoom
             return page.iiif.info()
         elif kwargs['mode'] == 'iiif':
-            return page.iiif.info().replace('info.json', kwargs['url'].rstrip('/'))
+            return page.iiif.info().replace('info.json', kwargs['url'].strip('/'))

--- a/readux/collection/views.py
+++ b/readux/collection/views.py
@@ -1,6 +1,7 @@
 from random import shuffle
 from urllib import urlencode
 
+from django.conf import settings
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404
@@ -38,7 +39,7 @@ class CollectionList(ListView):
     def get_queryset(self):
         solr = solr_interface()
         return solr.query(content_model=Collection.COLLECTION_CONTENT_MODEL) \
-                  .filter(owner='LSDI-project') \
+                  .filter(owner=settings.COLLECTIONS_OWNER) \
                   .sort_by('title_exact') \
                   .results_as(SolrCollection)
 

--- a/readux/localsettings.py.dist
+++ b/readux/localsettings.py.dist
@@ -160,9 +160,12 @@ IIIF_ID_PREFIX = 'prefix:'
 # optional suffix, used when loris expects datastream dilineation (e.g. '|source-image')
 IIIF_ID_SUFFIX = ''
 
-
 # override default git author name if desired
 # GIT_AUTHOR_NAME = 'readux'
+
+# Optional filter for Collections Cover list by owner of Fedora object
+# (empty string matches all or absent owners)
+COLLECTIONS_OWNER = ''
 
 
 # Logging


### PR DESCRIPTION
Abstracts out what appears to be a hard-coded Fedora object owner from the collections view.

Adds a new setting to `localsettings` for an optional collection owner filter.  If that variable is left blank, no filtering is done. 